### PR TITLE
Try "Allow" header for deleting Expense

### DIFF
--- a/pages/api/expenses/[id]/index.js
+++ b/pages/api/expenses/[id]/index.js
@@ -481,4 +481,7 @@ export default async function handler(req, res) {
 
     return res.status(200).send();
   }
+
+  res.setHeader('Allow', ['POST', 'GET', 'PUT', 'DELETE']);
+  return res.status(405).end(`Method ${method} Not Allowed`);
 }

--- a/pages/expenses/[id].js
+++ b/pages/expenses/[id].js
@@ -379,11 +379,11 @@ const Trash = styled(IconTrash)`
   transition: all 0.25s ease 0s;
   @media (hover: hover) and (pointer: fine) {
     :hover {
-      fill: ${({ theme }) => theme.colors.purple};
+      stroke: ${({ theme }) => theme.colors.purple};
     }
   }
   :active {
-    fill: ${({ theme }) => theme.colors.purple};
+    stroke: ${({ theme }) => theme.colors.purple};
   }
 `;
 
@@ -504,9 +504,8 @@ const Expense = (props) => {
   }, [expense?.active]);
 
   const deleteExpense = async () => {
-    const response = await fetch(`/api/expenses/${expense?.id}/delete`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const response = await fetch(`/api/expenses/${expense?.id}`, {
+      method: 'DELETE',
     });
 
     if (response.ok) {


### PR DESCRIPTION
- Set "Allow" header on blank method branch
- Update Expense to try DELETE endpoint

I'm not sure why this is being so stubborn. I noticed your idea of putting delete in it's own POST endpoint didn't work either. Very tricky! We'll get it with one of these tries.

This must be a Next.js v11 issue. I've never seen it with 12+ Next.js.