### PR TITLE
Try different router method after Expense DELETE

### DIFF
--- a/pages/expenses/[id].js
+++ b/pages/expenses/[id].js
@@ -508,8 +508,9 @@ const Expense = (props) => {
       method: 'DELETE',
     });
 
-    if (response.ok) {
-      Router.push('/dashboard');
+    // TODO: If this works, next try `Router.back()` without the outer condition
+    if (response.ok && typeof window !== 'undefined') {
+      history.back();
     }
   };
 


### PR DESCRIPTION
Researching this issue, I keep seeing things about `res.redirect` causing issues. This isn't exactly that but I'm wondering if Next.js is somehow interpreting this block as a redirect after execution and sending a 405? Feels like a hailmary but worth a shot.